### PR TITLE
fix: remove no-use-before-declare

### DIFF
--- a/tslint-base.json
+++ b/tslint-base.json
@@ -170,7 +170,6 @@
       "severity": "warning"
     },
     "no-unused-expression": true,
-    "no-use-before-declare": true,
     "no-use-of-empty-return-value": true,
     "no-useless-cast": true,
     "no-useless-increment": true,


### PR DESCRIPTION
no-use-before-declare is deprecated as of TypeScript 2.9